### PR TITLE
Fix NGINX config for CORS preflight requests

### DIFF
--- a/ansible-allinone-demo-vm/roles/nginx/templates/nginx.conf
+++ b/ansible-allinone-demo-vm/roles/nginx/templates/nginx.conf
@@ -156,10 +156,18 @@ http {
         add_header Referrer-Policy strict-origin-when-cross-origin;
 
         # Basic open CORS for everyone
-        add_header Access-Control-Allow-Origin $http_origin;
-        add_header Access-Control-Allow-Methods 'GET, POST';
-        add_header Access-Control-Allow-Credentials true;
-        add_header Access-Control-Allow-Headers 'Origin,Content-Type,Accept,Authorization';
+        add_header Access-Control-Allow-Origin $http_origin always;
+        add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS' always;
+        add_header Access-Control-Allow-Credentials true always;
+        add_header Access-Control-Allow-Headers 'Origin,Content-Type,Accept,Authorization' always;
+
+        # Always respond with 200 to OPTIONS requests as browsers do not accept
+        # non-200 responses to CORS preflight requests.
+        if ($request_method = OPTIONS) {
+            add_header 'Access-Control-Max-Age' 1728000;
+            add_header 'Content-Length' 0;
+            return 200;
+        }
 
         # Accept large ingests
         client_max_body_size 0;


### PR DESCRIPTION
CORS preflight requests are only accepted by browsers if the server responds with a 2xx code. Some browsers even only accept 200 as response response code, meaning we can't use 204. Before this commit, the request was handled by Opencast. This usually lead to a redirect because most endpoints are protected and Opencast wanted to redirect to the login page.

This helps with a few external applications, like Studio. See [this issue](https://github.com/elan-ev/opencast-studio/issues/377) for example. This also means that HTTP Basic auth is not usable from different origins, making it almost useless.

The `always` flags were added to allow CORS request that result in 404 for example. Without, the CORS headers are just added on the response codes 200, 201, 206, 301, 302, 303, 307, or 308 (as you can see [here](http://nginx.org/en/docs/http/ngx_http_headers_module.html)).

CC @lkiesow 