### PR TITLE
Add a few MIME-types to `gzip_types` to improve compression

### DIFF
--- a/ansible-allinone-demo-vm/roles/nginx/templates/nginx.conf
+++ b/ansible-allinone-demo-vm/roles/nginx/templates/nginx.conf
@@ -55,11 +55,17 @@ http {
     gzip_comp_level 2;
     gzip_min_length 1000;
     gzip_proxied    expired no-cache no-store private auth;
-    gzip_types      text/plain
-                    application/x-javascript
-                    text/xml
-                    text/css
-                    application/xml;
+    gzip_types
+        application/javascript
+        application/json
+        application/x-javascript
+        application/xml
+        image/svg+xml
+        text/css
+        text/javascript
+        text/js
+        text/plain
+        text/xml;
 
     # Do not send the nginx version number in error pages and Server header
     server_tokens off;


### PR DESCRIPTION
In particular, `text/javascript` was missing. Only `text/x-javascript` was
specified, which is rarely used anymore. I also added a few other MIMEs
that are sometimes used for JS files and the MIME for SVG files.

Also see [this StackOverflow post](https://stackoverflow.com/questions/12640014/enable-gzip-for-css-and-js-files-on-nginx-server-for-magento) for some information.