### PR TITLE
Add adopter registration ansible script

### DIFF
--- a/ansible-deploy-adopter-reg-server/hosts
+++ b/ansible-deploy-adopter-reg-server/hosts
@@ -1,0 +1,2 @@
+[reg]
+register.opencast.org

--- a/ansible-deploy-adopter-reg-server/registration-server.yml
+++ b/ansible-deploy-adopter-reg-server/registration-server.yml
@@ -59,6 +59,18 @@
             - core:
                 listen:
                   - address: 0.0.0.0
+                    port: 80
+                    http2: true
+                server_name: "{{ inventory_hostname }}"
+              locations:
+              - location:  /
+                rewrite:
+                  return:
+                    code: 301
+                    url: "https://{{ inventory_hostname }}$request_uri"
+            - core:
+                listen:
+                  - address: 0.0.0.0
                     port: 443
                     http2: true
                     ssl: true

--- a/ansible-deploy-adopter-reg-server/registration-server.yml
+++ b/ansible-deploy-adopter-reg-server/registration-server.yml
@@ -8,7 +8,7 @@
     - nginxinc.nginx_config
   vars:
     - reg_server_user: "opencast"
-    - reg_server_pass: "opencast"
+    - reg_server_pass: "{{ lookup('passwordstore', 'register.opencast.org/opencast') }}"
     - reg_server_salt: "{{ lookup('passwordstore', 'register.opencast.org/salt') }}"
     - nginx_manage_repo: false
     - nginx_install_from: os_repository

--- a/ansible-deploy-adopter-reg-server/registration-server.yml
+++ b/ansible-deploy-adopter-reg-server/registration-server.yml
@@ -1,0 +1,45 @@
+---
+
+- hosts: all
+  become: true
+  roles:
+    - adopter-reg-server
+    - nginxinc.nginx
+    - nginxinc.nginx_config
+  vars:
+    - reg_server_user: "opencast"
+    - reg_server_pass: "opencast"
+    - reg_server_salt: "{{ lookup('passwordstore', 'register.opencast.org/salt') }}"
+    - nginx_manage_repo: false
+    - nginx_install_from: os_repository
+    - nginx_setup_license: false
+    - nginx_selinux: true
+    - nginx_config_http_template_enable: true
+    - nginx_config_http_template:
+      - deployment_location: /etc/nginx/conf.d/oc-reg-server.conf
+        config:
+          servers:
+            - core:
+                listen:
+                  - address: 0.0.0.0
+                    port: 80
+                client_max_body_size: 0
+                server_name: "{{ inventory_hostname }}"
+              locations:
+              - location:  /
+                proxy:
+                  pass: http://localhost:8080
+                    #redirect:
+                    #original: http://$host
+                    #replacement: https://$host
+                    #set_header:
+                    #- field: Host
+                    #  value: $host
+                    #- field: X-Real-IP
+                    #  value: $remote_addr
+                    #- field: X-Forwarded-For
+                    #  value: $proxy_add_x_forwarded_for
+                    #- field: X-Forwarded-Proto
+                    #  value: $scheme
+                  buffering: false
+                  request_buffering: false

--- a/ansible-deploy-adopter-reg-server/registration-server.yml
+++ b/ansible-deploy-adopter-reg-server/registration-server.yml
@@ -2,10 +2,32 @@
 
 - hosts: all
   become: true
+  tasks:
+  - name: Ensuring epel is installed
+    package:
+      name: "epel-release"
+      state: present
+
+  - name: Installing git and python
+    package:
+      name: "{{ item }}"
+      state: present
+    with_items:
+      - python3-virtualenv
+      - python38
+      - python3-passlib
+      - git
+      - sqlite
+      #These are for nginx
+      - python3-libsemanage
+      - checkpolicy
+
+- hosts: all
+  become: true
   roles:
-    - adopter-reg-server
     - nginxinc.nginx
     - nginxinc.nginx_config
+    - adopter-reg-server
   vars:
     - reg_server_user: "opencast"
     - reg_server_pass: "{{ lookup('passwordstore', 'register.opencast.org/opencast') }}"

--- a/ansible-deploy-adopter-reg-server/registration-server.yml
+++ b/ansible-deploy-adopter-reg-server/registration-server.yml
@@ -22,6 +22,21 @@
       - python3-libsemanage
       - checkpolicy
 
+  - name: allow httpd to act as reverse proxy
+    seboolean:
+      name: httpd_can_network_relay
+      state: true
+      persistent: true
+    become: true
+
+  - name: create diffie hellman ephemeral parameters for nginx
+    community.crypto.openssl_dhparam:
+      path: /etc/nginx/ssl/dhparam.pem
+      size: 2048
+      owner: root
+      group: root
+      mode: '0640'
+
 - hosts: all
   become: true
   roles:
@@ -44,24 +59,44 @@
             - core:
                 listen:
                   - address: 0.0.0.0
-                    port: 80
+                    port: 443
+                    http2: true
+                    ssl: true
                 client_max_body_size: 0
                 server_name: "{{ inventory_hostname }}"
+              ssl:
+                certificate_key: /etc/nginx/ssl/{{ inventory_hostname }}.key
+                certificate: /etc/nginx/ssl/{{ inventory_hostname }}.crt
+                #session_cache:
+                   #builtin:
+                     #enable: true
+                     #size: 50m
+                dhparam: /etc/nginx/ssl/dhparam.pem
+                prefer_server_ciphers: true
+                ciphers: "HIGH:!aNULL:!MD5:!3DES"
               locations:
               - location:  /
                 proxy:
                   pass: http://localhost:8080
-                    #redirect:
-                    #original: http://$host
-                    #replacement: https://$host
-                    #set_header:
-                    #- field: Host
-                    #  value: $host
-                    #- field: X-Real-IP
-                    #  value: $remote_addr
-                    #- field: X-Forwarded-For
-                    #  value: $proxy_add_x_forwarded_for
-                    #- field: X-Forwarded-Proto
-                    #  value: $scheme
+                  cookie_path:
+                    - path: /
+                      replacement: '"/; HTTPOnly; Secure"'
                   buffering: false
                   request_buffering: false
+              headers:
+                add_headers:
+                  - name: Strict-Transport-Security
+                    value: '"max-age=31536000; includeSubdomains;"'
+                    always: true
+                  - name: X-Frame-Options
+                    value: SAMEORIGIN
+                    always: true
+                  - name: X-Content-Type-Options
+                    value: nosniff
+                    always: true
+                  - name: X-XSS-Protection
+                    value: '"1; mode=block"'
+                    always: true
+                  - name: Referrer-Policy
+                    value: strict-origin-when-cross-origin
+                    always: true

--- a/ansible-deploy-adopter-reg-server/requirements.yml
+++ b/ansible-deploy-adopter-reg-server/requirements.yml
@@ -1,0 +1,4 @@
+- src: nginxinc.nginx
+  version: 0.23.1
+- src: nginxinc.nginx_config
+  version: 0.5.1

--- a/ansible-deploy-adopter-reg-server/roles/adopter-reg-server/defaults/main.yml
+++ b/ansible-deploy-adopter-reg-server/roles/adopter-reg-server/defaults/main.yml
@@ -3,3 +3,7 @@
 adopter_reg_home: /opt/oc_adopter_reg
 
 adopter_reg_venv: "{{ adopter_reg_home }}/venv"
+
+#This is the ID of the opencast user once it has been created
+#Initially this ID belongs to the default admin superuser
+opencast_user_db_id: 1

--- a/ansible-deploy-adopter-reg-server/roles/adopter-reg-server/defaults/main.yml
+++ b/ansible-deploy-adopter-reg-server/roles/adopter-reg-server/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+adopter_reg_home: /opt/oc_adopter_reg
+
+adopter_reg_venv: "{{ adopter_reg_home }}/venv"

--- a/ansible-deploy-adopter-reg-server/roles/adopter-reg-server/tasks/main.yml
+++ b/ansible-deploy-adopter-reg-server/roles/adopter-reg-server/tasks/main.yml
@@ -1,22 +1,5 @@
 ---
 
-- name: Ensuring epel is installed
-  package:
-    name: "epel-release"
-    state: present
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
-
-- name: Installing git and python
-  package:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - python3-virtualenv
-    - python38
-    - python3-passlib
-    - git
-    - sqlite
-
 - name: Cloning adopter reg service
   git:
     #repo: https://github.com/opencast/adopter-registration-server.git

--- a/ansible-deploy-adopter-reg-server/roles/adopter-reg-server/tasks/main.yml
+++ b/ansible-deploy-adopter-reg-server/roles/adopter-reg-server/tasks/main.yml
@@ -1,0 +1,91 @@
+---
+
+- name: Ensuring epel is installed
+  package:
+    name: "epel-release"
+    state: present
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+
+- name: Installing git and python
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - python3-virtualenv
+    - python38
+    - python3-passlib
+    - git
+    - sqlite
+
+- name: Cloning adopter reg service
+  git:
+    #repo: https://github.com/opencast/adopter-registration-server.git
+    repo: https://github.com/gregorydlogan/adopter-registration-server.git
+    dest: "{{ adopter_reg_home}}"
+    force: yes
+
+- name: Creating python venv
+  command:
+    cmd: python3.8 -m venv {{ adopter_reg_venv }}
+    creates: "{{ adopter_reg_venv }}"
+
+- name: Updating python venv
+  pip:
+    name: "{{ item }}"
+    state: latest
+    executable: "{{ adopter_reg_venv }}/bin/pip3"
+  with_items:
+    - pip
+    - setuptools
+
+- name: Installing dependencies
+  pip:
+    requirements: "{{ adopter_reg_home }}/requirements.txt"
+    executable: "{{ adopter_reg_venv }}/bin/pip3"
+
+- name: Templating systemd unit file
+  template:
+    src: oc-reg-server.service
+    dest: /etc/systemd/system/oc-reg-server.service
+    owner: root
+    group: root
+    mode: 0644
+  become: yes
+
+- name: Generating Flask key
+  lineinfile:
+    path: "{{ adopter_reg_home }}/app/__init__.py"
+    search_string: "super secret key"
+    line: "app.secret_key = '{{ lookup('community.general.random_string', length=32, special=false) }}'"
+  become: yes
+
+- name: Updating password salt
+  lineinfile:
+    path: "{{ adopter_reg_home }}/config.py"
+    search_string: "SECURITY_PASSWORD_SALT = 'CHANGE_ME'"
+    line: "    SECURITY_PASSWORD_SALT = '{{ reg_server_salt }}'"
+
+- name: Enabling and starting systemd unit  
+  systemd:
+    name: oc-reg-server
+    state: started
+    enabled: yes
+    daemon_reload: yes
+  become: yes
+
+- name: Ensuring the database file exists
+  uri:
+    url:  http://{{ inventory_hostname }}/admin
+    return_content: yes
+  delegate_to: 127.0.0.1
+  become: no
+
+    #- name: Removing hardcoded superuser
+    #  command: sqlite3 {{ adopter_reg_home }}/instance/app.db 'DELETE FROM user WHERE email="admin"'
+
+- name: Removing generated user to update its password
+  command: sqlite3 {{ adopter_reg_home }}/instance/app.db 'DELETE FROM user WHERE email="{{ reg_server_user }}"'
+
+#Magic hash generation c/o https://nerdoftheherd.com/news/2021/12/30/ansible-mosquitto-password-hash/
+- name: Adding user
+  command: sqlite3 {{ adopter_reg_home }}/instance/app.db "INSERT INTO user VALUES(2,'{{ reg_server_user }}','{{ reg_server_pass | password_hash('pbkdf2-sha512', reg_server_salt) }}','2022-08-12 21:08:30.978482','2022-08-12 21:48:24.346835','127.0.0.1','127.0.0.1',2,1);"

--- a/ansible-deploy-adopter-reg-server/roles/adopter-reg-server/tasks/main.yml
+++ b/ansible-deploy-adopter-reg-server/roles/adopter-reg-server/tasks/main.yml
@@ -81,11 +81,11 @@
   become: no
 
 - name: Removing hardcoded superuser
-  command: sqlite3 {{ adopter_reg_home }}/instance/app.db 'DELETE FROM user WHERE email="admin"'
+  command: sqlite3 {{ adopter_reg_home }}/instance/app.db 'DELETE FROM user WHERE email="admin"; DELETE FROM roles_users WHERE user_id=1'
 
 - name: Removing generated user to update its password
-  command: sqlite3 {{ adopter_reg_home }}/instance/app.db 'DELETE FROM user WHERE email="{{ reg_server_user }}"'
+  command: sqlite3 {{ adopter_reg_home }}/instance/app.db 'DELETE FROM user WHERE email="{{ reg_server_user }}"; DELETE FROM roles_users WHERE user_id={{ opencast_user_db_id }};'
 
-#Magic hash generation c/o https://nerdoftheherd.com/news/2021/12/30/ansible-mosquitto-password-hash/
-- name: Adding user
-  command: sqlite3 {{ adopter_reg_home }}/instance/app.db "INSERT INTO user VALUES(2,'{{ reg_server_user }}','{{ reg_server_pass }}','1970-01-01 00:00:00.00000','1970-01-01 00:00:00.00000','','','',1);"
+  #Role ID 1 is superuser
+- name: Adding user and role
+  command: sqlite3 {{ adopter_reg_home }}/instance/app.db "INSERT INTO user VALUES({{ opencast_user_db_id }},'{{ reg_server_user }}','{{ reg_server_pass }}','1970-01-01 00:00:00.00000','1970-01-01 00:00:00.00000','','','',1); INSERT INTO roles_users VALUES({{ opencast_user_db_id }},1)"

--- a/ansible-deploy-adopter-reg-server/roles/adopter-reg-server/tasks/main.yml
+++ b/ansible-deploy-adopter-reg-server/roles/adopter-reg-server/tasks/main.yml
@@ -68,7 +68,7 @@
 - name: Enabling and starting systemd unit  
   systemd:
     name: oc-reg-server
-    state: started
+    state: restarted
     enabled: yes
     daemon_reload: yes
   become: yes
@@ -80,12 +80,12 @@
   delegate_to: 127.0.0.1
   become: no
 
-    #- name: Removing hardcoded superuser
-    #  command: sqlite3 {{ adopter_reg_home }}/instance/app.db 'DELETE FROM user WHERE email="admin"'
+- name: Removing hardcoded superuser
+  command: sqlite3 {{ adopter_reg_home }}/instance/app.db 'DELETE FROM user WHERE email="admin"'
 
 - name: Removing generated user to update its password
   command: sqlite3 {{ adopter_reg_home }}/instance/app.db 'DELETE FROM user WHERE email="{{ reg_server_user }}"'
 
 #Magic hash generation c/o https://nerdoftheherd.com/news/2021/12/30/ansible-mosquitto-password-hash/
 - name: Adding user
-  command: sqlite3 {{ adopter_reg_home }}/instance/app.db "INSERT INTO user VALUES(2,'{{ reg_server_user }}','{{ reg_server_pass | password_hash('pbkdf2-sha512', reg_server_salt) }}','2022-08-12 21:08:30.978482','2022-08-12 21:48:24.346835','127.0.0.1','127.0.0.1',2,1);"
+  command: sqlite3 {{ adopter_reg_home }}/instance/app.db "INSERT INTO user VALUES(2,'{{ reg_server_user }}','{{ reg_server_pass }}','1970-01-01 00:00:00.00000','1970-01-01 00:00:00.00000','','','',1);"

--- a/ansible-deploy-adopter-reg-server/roles/adopter-reg-server/tasks/main.yml
+++ b/ansible-deploy-adopter-reg-server/roles/adopter-reg-server/tasks/main.yml
@@ -58,7 +58,7 @@
 
 - name: Ensuring the database file exists
   uri:
-    url:  http://{{ inventory_hostname }}/admin
+    url:  https://{{ inventory_hostname }}/admin
     return_content: yes
   delegate_to: 127.0.0.1
   become: no

--- a/ansible-deploy-adopter-reg-server/roles/adopter-reg-server/templates/oc-reg-server.service
+++ b/ansible-deploy-adopter-reg-server/roles/adopter-reg-server/templates/oc-reg-server.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Opencast adopter registration server
+After=network.target
+
+[Service]
+#User=ubuntu
+WorkingDirectory={{ adopter_reg_home }}
+ExecStart={{ adopter_reg_venv }}/bin/gunicorn -b localhost:8080 -w 2 app:app
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds an Ansible playbook which deploys and configures Opencast's adopter registration server.

Notably absent is HTTPS certification configuration.  That's handled by @lkiesow currently, although with *a whole bunch of other certs*.  Actual usage of whatever cert is present *is* configured by this playbook.
