### PR TITLE
Fix reg server config mistakes

### DIFF
--- a/ansible-deploy-adopter-reg-server/registration-server.yml
+++ b/ansible-deploy-adopter-reg-server/registration-server.yml
@@ -60,7 +60,6 @@
                 listen:
                   - address: 0.0.0.0
                     port: 80
-                    http2: true
                 server_name: "{{ inventory_hostname }}"
               locations:
               - location:  /

--- a/ansible-deploy-adopter-reg-server/registration-server.yml
+++ b/ansible-deploy-adopter-reg-server/registration-server.yml
@@ -88,7 +88,7 @@
               locations:
               - location:  /
                 proxy:
-                  pass: http://localhost:8080
+                  pass: http://127.0.0.1:8080
                   cookie_path:
                     - path: /
                       replacement: '"/; HTTPOnly; Secure"'


### PR DESCRIPTION
Fixes a couple of dumb mistakes in the adopter registration server config.  This is already deployed in prod.

- Removing incorrect http2 usage
- Fixing proxy pass location for adopter reg server
