### PR TITLE
Enable setting ACLs in ingest script

### DIFF
--- a/ansible-demo-machines/roles/opencast/templates/media.yml
+++ b/ansible-demo-machines/roles/opencast/templates/media.yml
@@ -5,8 +5,17 @@ server:
   password: opencast
 
 acl:
-  - role: ROLE_ANONYMOUS
-    action: read
+  public:
+    - role: ROLE_ANONYMOUS
+      action: read
+  authenticated:
+    - role: ROLE_USER
+      action: read
+    - role: ROLE_ADMIN
+      action: write
+  private:
+    - role: ROLE_ADMIN
+      action: write
 
 series:
   - identifier: ID-blender-foundation


### PR DESCRIPTION
This PR enables setting the ACLs in both the series, and episodes.  Not currently used, but something that might come in handy in the future (and something I needed to build for internal use anyway)
