### PR TITLE
Fix analysis-cru install

### DIFF
--- a/ansible-demo-machines/roles/opencast/templates/opencast-build.sh
+++ b/ansible-demo-machines/roles/opencast/templates/opencast-build.sh
@@ -36,17 +36,18 @@ restorecon -r /srv/opencast/ || :
 chcon -Rt httpd_sys_content_t /srv/opencast/opencast-dist-allinone/data/log || :
 chcon -R system_u:object_r:bin_t:s0 /srv/opencast/opencast-dist-allinone/bin/ || :
 
+#Ensure the plugin required for 16.x+ is present
+if [ ! -d /usr/share/elasticsearch/plugins/analysis-icu ]; then
+  #If the analysis-icu directory does not exist, install the thing
+  sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install -b analysis-icu
+fi
+
 # Clear Elasticsearch
 sudo systemctl stop elasticsearch.service
 sudo rm -rf /var/lib/elasticsearch/nodes
 sudo systemctl restart elasticsearch.service
 
 sleep 10
-
-if [ ! -d /usr/share/elasticsearch/plugins/analysis-icu ]; then
-  #If the analysis-icu directory does not exist, install the thing
-  /usr/share/elasticsearch/bin/elasticsearch-plugin install -b analysis-icu
-fi
 
 # Start Opencast
 sudo systemctl start opencast.service


### PR DESCRIPTION
This PR:
- Installs the analysis plugin plugin properly, if required.  Previously was not sudo-ing the install, which then failed because the script runs as `opencast` and not `root`
- Install the above plugin prior to restarting elasticsearch.  I'm unsure if this is *required*, but it can't hurt either.
