### PR TITLE
Support installing specific revision of adopter registration server

### DIFF
--- a/ansible-deploy-adopter-reg-server/hosts
+++ b/ansible-deploy-adopter-reg-server/hosts
@@ -1,2 +1,2 @@
 [reg]
-register.opencast.org
+register.opencast.org adopter_reg_version="aed0b4babbfa864724129296e9927f369d235c62"

--- a/ansible-deploy-adopter-reg-server/roles/adopter-reg-server/defaults/main.yml
+++ b/ansible-deploy-adopter-reg-server/roles/adopter-reg-server/defaults/main.yml
@@ -6,6 +6,8 @@ adopter_reg_home: /opt/oc_adopter_reg
 
 adopter_reg_venv: "{{ adopter_reg_home }}/venv"
 
+adopter_reg_version: "HEAD"
+
 # This is the ID of the opencast user once it has been created
 # Initially this ID belongs to the default admin superuser
 opencast_user_db_id: 1

--- a/ansible-deploy-adopter-reg-server/roles/adopter-reg-server/tasks/main.yml
+++ b/ansible-deploy-adopter-reg-server/roles/adopter-reg-server/tasks/main.yml
@@ -14,6 +14,7 @@
     repo: https://github.com/opencast/adopter-registration-server.git
     dest: "{{ adopter_reg_home }}"
     force: true
+    version: "{{ adopter_reg_version }}"
   become_user: "{{ adopter_server_user }}"
 
 - name: Creating python venv


### PR DESCRIPTION
Currently we just install whatever HEAD is, but that's not ideal in some cases.
