### PR TITLE
Add JDK 21 to demo machine instances

### DIFF
--- a/ansible-demo-machines/roles/opencast/tasks/debian.yml
+++ b/ansible-demo-machines/roles/opencast/tasks/debian.yml
@@ -8,6 +8,7 @@
   ansible.builtin.package:
     name:
       - openjdk-17-jre
+      - openjdk-21-jre
       - curl
       - ffmpeg-dist
       - netcat

--- a/ansible-demo-machines/roles/opencast/tasks/el9.yml
+++ b/ansible-demo-machines/roles/opencast/tasks/el9.yml
@@ -12,6 +12,7 @@
       - ffmpeg
       - tar
       - java-17-openjdk
+      - java-21-openjdk
       - gzip
       - tesseract
       - elasticsearch-oss


### PR DESCRIPTION
This PR follows https://github.com/opencast/opencast/pull/6472, which bumped the minimum JDK for OC18+ to JDK 21
