### PR TITLE
Readonly Demo media

### DIFF
--- a/ansible-demo-machines/roles/nginx/templates/nginx.conf
+++ b/ansible-demo-machines/roles/nginx/templates/nginx.conf
@@ -154,6 +154,32 @@ http {
         client_max_body_size 0;
 
         # Proxy configuration for Opencast
+        location ~* (?=ID-dual-stream-demo) {
+            limit_except GET {
+              allow {{ inventory_hostname }};
+              deny all;
+            }
+
+            proxy_set_header        Host $host;
+            proxy_set_header        X-Real-IP $remote_addr;
+            proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header        X-Forwarded-Proto $scheme;
+
+            proxy_pass              http://127.0.0.1:8080;
+
+            # Make sure to redirect location headers to HTTPS
+            proxy_redirect          http://$host https://$host;
+
+            proxy_cookie_path / "/; HTTPOnly; Secure";
+
+            # Do not buffer responses
+            proxy_buffering         off;
+
+            # Do not buffer requests
+            proxy_request_buffering off;
+        }
+
+        # Proxy configuration for Opencast
         location / {
 
             proxy_set_header        Host $host;

--- a/ansible-demo-machines/roles/opencast/templates/media.yml
+++ b/ansible-demo-machines/roles/opencast/templates/media.yml
@@ -149,7 +149,7 @@ media:
     - mediaUri: https://radosgw.public.os.wwu.de/opencast-test-media/dualstream-presentation.mp4
     - flavor: captions/source+en
     - mediaUri: https://radosgw.public.os.wwu.de/opencast-test-media/dualstream.vtt
-    - title: Dual-Stream Demo
+    - title: Dual-Stream Demo (READ ONLY)
     - creator: Lars Kiesow
     - identifier: ID-dual-stream-demo
     - license: CC-BY-SA


### PR DESCRIPTION
Occasionally we have situations where the dual stream demo event gets removed from our testing infrastructure.  These events are used by other testing infrastructure (cf, the editor), which makes for broken test infrastructure in non-obvious ways.  Ideally, we would have a way to make the required event read only, but in the meantime this (ab)uses the nginx proxy to refuse requests to do so.

What this stops:
- the admin UI's red X to delete the event
- the external API's ability to delete the event

What I'm unsure about:
- Graphql (which is *probably* disabled by default, but perhaps should be turned on?)

What this *definitely* doesn't handle:
- Starting a retract task.  nginx doesn't seem to support munging based on post data (huh, wonder why...).  If someone has an idea of how to do this, please let me know!