### PR TITLE
Update demo infra after 19.x branch cut

### DIFF
--- a/ansible-demo-machines/hosts.yml
+++ b/ansible-demo-machines/hosts.yml
@@ -2,17 +2,17 @@ all:
   hosts:
     develop.opencast.org:
       # for repository:
-      opencast_version_major: 19
+      opencast_version_major: 20
       # for tarball:
-      version: 19-SNAPSHOT
+      version: 20-SNAPSHOT
       java_version: 21
     stable.opencast.org:
-      opencast_version_major: 18
-      version: 18-SNAPSHOT
+      opencast_version_major: 19
+      version: 19-SNAPSHOT
       java_version: 21
     legacy.opencast.org:
-      opencast_version_major: 17
-      version: 17-SNAPSHOT
+      opencast_version_major: 18
+      version: 18-SNAPSHOT
       java_version: 21
   vars:
     opencast_repository_enabled_release: true


### PR DESCRIPTION
This PR updates the demo infra machines to the correct versions now that 19.x has been cut
