### PR TITLE
Updating demo machine versions due to 21 branch cut

### DIFF
--- a/ansible-demo-machines/hosts.yml
+++ b/ansible-demo-machines/hosts.yml
@@ -2,17 +2,17 @@ all:
   hosts:
     develop.opencast.org:
       # for repository:
-      opencast_version_major: 20
+      opencast_version_major: 21
       # for tarball:
-      version: 20-SNAPSHOT
+      version: 21-SNAPSHOT
       java_version: 21
     stable.opencast.org:
-      opencast_version_major: 19
-      version: 19-SNAPSHOT
+      opencast_version_major: 20
+      version: 20-SNAPSHOT
       java_version: 21
     legacy.opencast.org:
-      opencast_version_major: 18
-      version: 18-SNAPSHOT
+      opencast_version_major: 19
+      version: 19-SNAPSHOT
       java_version: 21
   vars:
     opencast_repository_enabled_release: true


### PR DESCRIPTION
All Opencast versions got incremented due to the Opencast 21 release cut.